### PR TITLE
341624 add status attribute to room

### DIFF
--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -131,6 +131,6 @@ class RoomsController < ApplicationController
 
   # Never trust parameters from the scary internet, only allow the white list through.
   def room_params
-    params.require(:room).permit(:name, :description, :display_on_home_page, :position, :site_id)
+    params.require(:room).permit(:name, :description, :display_on_home_page, :position, :status, :site_id)
   end
 end

--- a/app/decorators/room_decorator.rb
+++ b/app/decorators/room_decorator.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
 class RoomDecorator < ApplicationDecorator
+  BADGE_COLORS = {
+    active: "text-bg-success",
+    passive: "text-bg-warning",
+    planned: "text-bg-primary"
+  }.freeze
+
   class << self
     def statuses_for_options
       Room.statuses.keys.map { |status| [Room.human_attribute_name("status.#{status}"), status] }
@@ -8,13 +14,6 @@ class RoomDecorator < ApplicationDecorator
   end
 
   def badge_color_for_status
-    case status
-    when "active"
-      "text-bg-success"
-    when "passive"
-      "text-bg-warning"
-    when "planned"
-      "text-bg-primary"
-    end
+    BADGE_COLORS[status.to_sym]
   end
 end

--- a/app/decorators/room_decorator.rb
+++ b/app/decorators/room_decorator.rb
@@ -6,4 +6,15 @@ class RoomDecorator < ApplicationDecorator
       Room.statuses.keys.map { |status| [Room.human_attribute_name("status.#{status}"), status] }
     end
   end
+
+  def badge_color_for_status
+    case status
+    when "active"
+      "text-bg-success"
+    when "passive"
+      "text-bg-warning"
+    when "planned"
+      "text-bg-primary"
+    end
+  end
 end

--- a/app/decorators/room_decorator.rb
+++ b/app/decorators/room_decorator.rb
@@ -2,7 +2,7 @@
 
 class RoomDecorator < ApplicationDecorator
   class << self
-    def status_for_options
+    def statuses_for_options
       Room.statuses.keys.map { |status| [Room.human_attribute_name("status.#{status}"), status] }
     end
   end

--- a/app/decorators/room_decorator.rb
+++ b/app/decorators/room_decorator.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class RoomDecorator < ApplicationDecorator
+  class << self
+    def status_for_options
+      Room.statuses.keys.map { |status| [Room.human_attribute_name("status.#{status}"), status] }
+    end
+  end
+end

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -13,7 +13,7 @@ class Room < ApplicationRecord
   has_many :frames, through: :bays, dependent: :restrict_with_error
   has_many :materials, through: :frames, dependent: :restrict_with_error
 
-  enum :status, [:active, :passive, :planned]
+  enum :status, { :active => 0, :passive => 1, :planned => 2 }, default: :active, validate: true
 
   scope :sorted, -> { order(:site_id, :position, :name) }
   scope :not_empty, -> { joins(:servers) }

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -13,7 +13,7 @@ class Room < ApplicationRecord
   has_many :frames, through: :bays, dependent: :restrict_with_error
   has_many :materials, through: :frames, dependent: :restrict_with_error
 
-  enum :status, { active: 0, passive: 1, planned: 2 }, default: :active, validate: true
+  enum :status, { active: 0, passive: 1, planned: 2 }, validate: true
 
   scope :sorted, -> { order(:site_id, :position, :name) }
   scope :not_empty, -> { joins(:servers) }

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -13,6 +13,8 @@ class Room < ApplicationRecord
   has_many :frames, through: :bays, dependent: :restrict_with_error
   has_many :materials, through: :frames, dependent: :restrict_with_error
 
+  enum :status, [:active, :passive, :planned]
+
   scope :sorted, -> { order(:site_id, :position, :name) }
   scope :not_empty, -> { joins(:servers) }
 

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -13,7 +13,7 @@ class Room < ApplicationRecord
   has_many :frames, through: :bays, dependent: :restrict_with_error
   has_many :materials, through: :frames, dependent: :restrict_with_error
 
-  enum :status, { :active => 0, :passive => 1, :planned => 2 }, default: :active, validate: true
+  enum :status, { active: 0, passive: 1, planned: 2 }, default: :active, validate: true
 
   scope :sorted, -> { order(:site_id, :position, :name) }
   scope :not_empty, -> { joins(:servers) }

--- a/app/processors/rooms_processor.rb
+++ b/app/processors/rooms_processor.rb
@@ -2,7 +2,7 @@
 
 class RoomsProcessor < ApplicationProcessor
   include Sortable
-  SORTABLE_FIELDS = %w[name position sites.name islets_count display_on_home_page].freeze
+  SORTABLE_FIELDS = %w[name position sites.name islets_count display_on_home_page status].freeze
 
   map :q do |q:|
     raw.where(Room.arel_table[:name].matches("%#{q}%"))

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -4,14 +4,17 @@
   <div class="img-fluid m-0 py-5 px-2 rounded"
         style="background: url(<%= asset_path('_78A0587-nb.jpg') %>) no-repeat center; background-size: cover;">
     <div class="container-fluid mt-4">
-      <% Site.joins(:rooms).where('display_on_home_page = ?', true).distinct.order(:position).each do |site| %>
+      <% Site.joins(:rooms).where('display_on_home_page = ? and status != ?', true, Room.statuses[:passive]).distinct.order(:position).each do |site| %>
         <div class="container-fluid mb-4 py-2 bg-body-tertiary bg-opacity-75 rounded border">
           <div class="text-center fs-4 mb-2"><%= site %></div>
           <div class="d-flex justify-content-between flex-wrap">
-            <% rooms = site.rooms.where(display_on_home_page: true).order(:position) %>
+            <% rooms = site.rooms.where(display_on_home_page: true).not_passive.order(:position) %>
             <% rooms.each do |room| %>
-              <div class="flex-fill border border-primary-subtle m-2 p-2 rounded">
-                <div class="text-start mb-1 fs-5"><%= link_to room.name, room %></div>
+              <div class="<%= class_names("flex-fill border border-primary-subtle m-2 p-2 rounded",
+                                          "border-secondary-subtle opacity-50": room.planned?)%>">
+                <div class="text-start mb-1 fs-5">
+                  <%= link_to room.name, room, class: class_names("link-secondary": room.planned?) %>
+                </div>
                 <ul>
                   <li><%= "#{Frame.model_name.human} : #{room.frames.count}" %></li>
                   <% Category.all.each do |cat| %>

--- a/app/views/rooms/_form.html.erb
+++ b/app/views/rooms/_form.html.erb
@@ -33,6 +33,13 @@
         <%= f.label :display_on_home_page, class: "form-check-label" %>
       </fieldset>
     </div>
+
+    <fieldset class="col-12 mt-4">
+      <%= f.label :status, class: "form-label" %>
+      <%= f.select :status, RoomDecorator::status_for_options,
+                            { },
+                            class: "form-select" %>
+    </fieldset>
   <% end %>
 
   <div class="col-12 py-4 mt-4 text-end sticky-bottom bg-body-tertiary border-top">

--- a/app/views/rooms/_form.html.erb
+++ b/app/views/rooms/_form.html.erb
@@ -36,7 +36,7 @@
 
     <fieldset class="col-12 mt-4">
       <%= f.label :status, class: "form-label" %>
-      <%= f.select :status, RoomDecorator::status_for_options,
+      <%= f.select :status, RoomDecorator::statuses_for_options,
                             { },
                             class: "form-select" %>
     </fieldset>

--- a/app/views/rooms/index.html.erb
+++ b/app/views/rooms/index.html.erb
@@ -69,6 +69,10 @@
         <input type="checkbox" <%= room.display_on_home_page ? "checked" : "" %> disabled>
       <% end %>
 
+      <% table.with_column(Room.human_attribute_name(:status), sort_by: :status) do |room| %>
+        <%= Room.human_attribute_name("status.#{room.status}") %>
+      <% end %>
+
       <% table.with_column(style: "min-width: 132px; width: 132px") do |room| %>
         <div class="btn-group btn-group-sm" role="group" aria-label="...">
           <%= render partial: "rooms/export_button", locals: { room: room } %>

--- a/app/views/rooms/index.html.erb
+++ b/app/views/rooms/index.html.erb
@@ -70,7 +70,9 @@
       <% end %>
 
       <% table.with_column(Room.human_attribute_name(:status), sort_by: :status) do |room| %>
-        <%= Room.human_attribute_name("status.#{room.status}") %>
+        <span class="badge rounded-pill <%= room.decorated.badge_color_for_status %>">
+          <%= Room.human_attribute_name("status.#{room.status}") %>
+        </span>
       <% end %>
 
       <% table.with_column(style: "min-width: 132px; width: 132px") do |room| %>

--- a/app/views/rooms/show.html.erb
+++ b/app/views/rooms/show.html.erb
@@ -50,6 +50,9 @@
           <dd class="mb-0 pb-2 ps-3">
             <span><%= t("boolean.#{@room.display_on_home_page}") %></span>
           </dd>
+
+          <dt class="pb-2"><%= Room.human_attribute_name(:status) %></dt>
+          <dd class="mb-0 pb-2 ps-3"><%= Room.human_attribute_name("status.#{@room.status}") %></dd>
         </dl>
       <% end %>
     </div>

--- a/app/views/rooms/show.html.erb
+++ b/app/views/rooms/show.html.erb
@@ -52,7 +52,11 @@
           </dd>
 
           <dt class="pb-2"><%= Room.human_attribute_name(:status) %></dt>
-          <dd class="mb-0 pb-2 ps-3"><%= Room.human_attribute_name("status.#{@room.status}") %></dd>
+          <dd class="mb-0 pb-2 ps-3">
+            <span class="badge rounded-pill <%= @room.decorated.badge_color_for_status %>">
+              <%= Room.human_attribute_name("status.#{@room.status}") %>
+            </span>
+          </dd>
         </dl>
       <% end %>
     </div>

--- a/config/locales/activerecord.fr.yml
+++ b/config/locales/activerecord.fr.yml
@@ -57,6 +57,7 @@ fr:
         content: Contenu
         display_on_home_page: Afficher sur la page d'accueil
         site_id: Site
+        status: Statut
         islets_count:
           zero: 0 îlot
           one: 1 îlot
@@ -65,6 +66,10 @@ fr:
           zero: 0 châssis
           one: 1 châssis
           other: "%{count} châssis"
+      room/status:
+        active: Actif
+        passive: Passif
+        planned: Planifié
       islet:
         name: Nom
         room_id: Salle

--- a/db/migrate/20241023101945_add_status_attribute_to_room.rb
+++ b/db/migrate/20241023101945_add_status_attribute_to_room.rb
@@ -1,7 +1,20 @@
 # frozen_string_literal: true
 
+class MigrationRoom < ActiveRecord::Base
+  self.table_name = :rooms
+end
+
 class AddStatusAttributeToRoom < ActiveRecord::Migration[7.2]
   def change
-    add_column :rooms, :status, :string
+    add_column :rooms, :status, :integer
+
+    up_only do
+      MigrationRoom.find_each do |room|
+        status = room.display_on_home_page ? 0 : 1
+        room.update(status: status)
+      end
+
+      change_column_null(:rooms, :status, false)
+    end
   end
 end

--- a/db/migrate/20241023101945_add_status_attribute_to_room.rb
+++ b/db/migrate/20241023101945_add_status_attribute_to_room.rb
@@ -6,15 +6,13 @@ end
 
 class AddStatusAttributeToRoom < ActiveRecord::Migration[7.2]
   def change
-    add_column :rooms, :status, :integer
+    add_column :rooms, :status, :integer, default: 0, null: false
 
     up_only do
       MigrationRoom.find_each do |room|
         status = room.display_on_home_page ? 0 : 1
         room.update!(status: status)
       end
-
-      change_column_null(:rooms, :status, false)
     end
   end
 end

--- a/db/migrate/20241023101945_add_status_attribute_to_room.rb
+++ b/db/migrate/20241023101945_add_status_attribute_to_room.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddStatusAttributeToRoom < ActiveRecord::Migration[7.2]
+  def change
+    add_column :rooms, :status, :string
+  end
+end

--- a/db/migrate/20241023101945_add_status_attribute_to_room.rb
+++ b/db/migrate/20241023101945_add_status_attribute_to_room.rb
@@ -11,7 +11,7 @@ class AddStatusAttributeToRoom < ActiveRecord::Migration[7.2]
     up_only do
       MigrationRoom.find_each do |room|
         status = room.display_on_home_page ? 0 : 1
-        room.update(status: status)
+        room.update!(status: status)
       end
 
       change_column_null(:rooms, :status, false)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_10_17_155157) do
+ActiveRecord::Schema[7.2].define(version: 2024_10_23_101945) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -416,6 +416,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_17_155157) do
     t.boolean "display_on_home_page"
     t.integer "site_id", null: false
     t.integer "islets_count", default: 0
+    t.string "status"
     t.index ["site_id"], name: "index_rooms_on_site_id"
     t.index ["slug"], name: "index_rooms_on_slug", unique: true
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -416,7 +416,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_23_101945) do
     t.boolean "display_on_home_page"
     t.integer "site_id", null: false
     t.integer "islets_count", default: 0
-    t.integer "status", null: false
+    t.integer "status", default: 0, null: false
     t.index ["site_id"], name: "index_rooms_on_site_id"
     t.index ["slug"], name: "index_rooms_on_slug", unique: true
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -416,7 +416,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_23_101945) do
     t.boolean "display_on_home_page"
     t.integer "site_id", null: false
     t.integer "islets_count", default: 0
-    t.string "status"
+    t.integer "status", null: false
     t.index ["site_id"], name: "index_rooms_on_site_id"
     t.index ["slug"], name: "index_rooms_on_slug", unique: true
   end

--- a/spec/decorators/room_decorator_spec.rb
+++ b/spec/decorators/room_decorator_spec.rb
@@ -6,4 +6,30 @@ RSpec.describe RoomDecorator, type: :decorator do
   describe ".statuses_for_options" do
     it { expect(described_class.statuses_for_options.pluck(1)).to match_array(Room.statuses.keys) }
   end
+
+  describe "#badge_color_for_status" do
+    let(:subject) { rooms(:one).decorated }
+
+    context "with status = active" do
+      it { expect(subject.badge_color_for_status).to eq "text-bg-success" }
+    end
+
+    context "with status = passive" do
+      before { rooms(:one).status = :passive }
+
+      it { expect(subject.badge_color_for_status).to eq "text-bg-warning" }
+    end
+
+    context "with status = planned" do
+      before { rooms(:one).status = :planned }
+
+      it { expect(subject.badge_color_for_status).to eq "text-bg-primary" }
+    end
+
+    context "with status = unknown" do
+      before { rooms(:one).status = :unknown }
+
+      it { expect(subject.badge_color_for_status).to be_nil }
+    end
+  end
 end

--- a/spec/decorators/room_decorator_spec.rb
+++ b/spec/decorators/room_decorator_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe RoomDecorator, type: :decorator do
-  describe ".status_for_options" do
-    it { expect(described_class.status_for_options.pluck(1)).to match_array(Room.statuses.keys) }
+  describe ".statuses_for_options" do
+    it { expect(described_class.statuses_for_options.pluck(1)).to match_array(Room.statuses.keys) }
   end
 end

--- a/spec/decorators/room_decorator_spec.rb
+++ b/spec/decorators/room_decorator_spec.rb
@@ -8,28 +8,28 @@ RSpec.describe RoomDecorator, type: :decorator do
   end
 
   describe "#badge_color_for_status" do
-    let(:subject) { rooms(:one).decorated }
+    subject(:badge_color) { rooms(:one).decorated.badge_color_for_status }
 
     context "with status = active" do
-      it { expect(subject.badge_color_for_status).to eq "text-bg-success" }
+      it { is_expected.to eq "text-bg-success" }
     end
 
     context "with status = passive" do
       before { rooms(:one).status = :passive }
 
-      it { expect(subject.badge_color_for_status).to eq "text-bg-warning" }
+      it { is_expected.to eq "text-bg-warning" }
     end
 
     context "with status = planned" do
       before { rooms(:one).status = :planned }
 
-      it { expect(subject.badge_color_for_status).to eq "text-bg-primary" }
+      it { is_expected.to eq "text-bg-primary" }
     end
 
     context "with status = unknown" do
       before { rooms(:one).status = :unknown }
 
-      it { expect(subject.badge_color_for_status).to be_nil }
+      it { is_expected.to be_nil }
     end
   end
 end

--- a/spec/decorators/room_decorator_spec.rb
+++ b/spec/decorators/room_decorator_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe RoomDecorator, type: :decorator do
+  describe ".status_for_options" do
+    it { expect(described_class.status_for_options.pluck(1)).to match_array(Room.statuses.keys) }
+  end
+end

--- a/spec/models/room_spec.rb
+++ b/spec/models/room_spec.rb
@@ -15,6 +15,15 @@ RSpec.describe Room do
     it { is_expected.to have_many(:materials).through(:frames) }
   end
 
+  describe "validations" do
+    it do
+      is_expected.to define_enum_for(:status) # rubocop:disable RSpec/ImplicitSubject
+        .with_default(:active)
+        .validating
+        .with_values([:active, :passive, :planned])
+    end
+  end
+
   describe "#to_s" do
     it { expect(room.to_s).to eq room.name }
   end

--- a/spec/models/room_spec.rb
+++ b/spec/models/room_spec.rb
@@ -18,7 +18,6 @@ RSpec.describe Room do
   describe "validations" do
     it do
       is_expected.to define_enum_for(:status) # rubocop:disable RSpec/ImplicitSubject
-        .with_default(:active)
         .validating
         .with_values(%i[active passive planned])
     end

--- a/spec/models/room_spec.rb
+++ b/spec/models/room_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Room do
       is_expected.to define_enum_for(:status) # rubocop:disable RSpec/ImplicitSubject
         .with_default(:active)
         .validating
-        .with_values([:active, :passive, :planned])
+        .with_values(%i[active passive planned])
     end
   end
 

--- a/test/fixtures/rooms.yml
+++ b/test/fixtures/rooms.yml
@@ -6,7 +6,6 @@ one:
   description: Room n°1
   site_id: 1
   display_on_home_page: true
-  status: :active
 
 two:
   id: 2
@@ -14,7 +13,6 @@ two:
   description: Room n°2
   site_id: 1
   display_on_home_page: true
-  status: :active
 
 three:
   id: 3
@@ -22,18 +20,15 @@ three:
   description: Room n°3
   site_id: 2
   display_on_home_page: false
-  status: :active
 
 four:
   id: 4
   name: S4
   description: Room n°4
   site_id: 2
-  status: :active
 
 five:
   id: 5
   name: S5
   description: Room n°5
   site_id: 1
-  status: :active

--- a/test/fixtures/rooms.yml
+++ b/test/fixtures/rooms.yml
@@ -6,6 +6,7 @@ one:
   description: Room n°1
   site_id: 1
   display_on_home_page: true
+  status: :active
 
 two:
   id: 2
@@ -13,6 +14,7 @@ two:
   description: Room n°2
   site_id: 1
   display_on_home_page: true
+  status: :active
 
 three:
   id: 3
@@ -20,15 +22,18 @@ three:
   description: Room n°3
   site_id: 2
   display_on_home_page: false
+  status: :active
 
 four:
   id: 4
   name: S4
   description: Room n°4
   site_id: 2
+  status: :active
 
 five:
   id: 5
   name: S5
   description: Room n°5
   site_id: 1
+  status: :active


### PR DESCRIPTION
>  Salle : ajouter un champ "Statut" avec valeurs "Actif / Passif / Plannifié". Lorsqu'un Site est affiché sur la page d’accueil, représenter les salles active, plannifié (en grisé/transparent).